### PR TITLE
Add environment-specific folders for AKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# azure_terraform
+# Azure Terraform AKS Environments
+
+This repository contains Terraform configuration to deploy Azure Kubernetes Service (AKS) clusters for `dev`, `test` and `prod` environments. The reusable module under `modules/aks` provisions a resource group and cluster for any environment.
+
+## Structure
+
+- `main.tf` & `variables.tf` - sample root configuration that deploys all environments at once using a map variable.
+- `terraform.tfvars` - sample values for the combined deployment.
+- `envs/<env>` - folders to manage environments individually (`dev`, `test`, `prod`). Each contains its own `main.tf`, `variables.tf`, and `terraform.tfvars`.
+- `modules/aks` - reusable module that creates a resource group and AKS cluster.
+
+## Usage
+
+### Deploy all environments at once
+
+1. Ensure Terraform is installed and your Azure credentials are configured for the `azurerm` provider.
+2. Edit `terraform.tfvars` in the repo root to match your desired settings.
+3. Initialize and apply:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+The `kube_configs` output will contain the kubeconfig for each deployed cluster.
+
+### Deploy a single environment
+
+1. Change into one of the environment folders under `envs` (e.g. `cd envs/dev`).
+2. Update the `terraform.tfvars` file in that folder if necessary.
+3. Run Terraform commands in that directory:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+The `kube_config` output will contain the kubeconfig for that specific cluster.

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -1,0 +1,8 @@
+module "aks" {
+  source              = "../../modules/aks"
+  environment         = "dev"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  kubernetes_version  = var.kubernetes_version
+  node_count          = var.node_count
+}

--- a/envs/dev/outputs.tf
+++ b/envs/dev/outputs.tf
@@ -1,0 +1,5 @@
+output "kube_config" {
+  value       = module.aks.kube_config
+  description = "Kubeconfig for dev cluster"
+  sensitive   = true
+}

--- a/envs/dev/terraform.tfvars
+++ b/envs/dev/terraform.tfvars
@@ -1,0 +1,4 @@
+resource_group_name = "dev-rg"
+location            = "eastus"
+kubernetes_version  = "1.27.3"
+node_count          = 1

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -1,0 +1,4 @@
+variable "resource_group_name" { type = string }
+variable "location" { type = string }
+variable "kubernetes_version" { type = string }
+variable "node_count" { type = number }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -1,0 +1,8 @@
+module "aks" {
+  source              = "../../modules/aks"
+  environment         = "prod"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  kubernetes_version  = var.kubernetes_version
+  node_count          = var.node_count
+}

--- a/envs/prod/outputs.tf
+++ b/envs/prod/outputs.tf
@@ -1,0 +1,5 @@
+output "kube_config" {
+  value       = module.aks.kube_config
+  description = "Kubeconfig for prod cluster"
+  sensitive   = true
+}

--- a/envs/prod/terraform.tfvars
+++ b/envs/prod/terraform.tfvars
@@ -1,0 +1,4 @@
+resource_group_name = "prod-rg"
+location            = "eastus"
+kubernetes_version  = "1.27.3"
+node_count          = 3

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -1,0 +1,4 @@
+variable "resource_group_name" { type = string }
+variable "location" { type = string }
+variable "kubernetes_version" { type = string }
+variable "node_count" { type = number }

--- a/envs/test/main.tf
+++ b/envs/test/main.tf
@@ -1,0 +1,8 @@
+module "aks" {
+  source              = "../../modules/aks"
+  environment         = "test"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  kubernetes_version  = var.kubernetes_version
+  node_count          = var.node_count
+}

--- a/envs/test/outputs.tf
+++ b/envs/test/outputs.tf
@@ -1,0 +1,5 @@
+output "kube_config" {
+  value       = module.aks.kube_config
+  description = "Kubeconfig for test cluster"
+  sensitive   = true
+}

--- a/envs/test/terraform.tfvars
+++ b/envs/test/terraform.tfvars
@@ -1,0 +1,4 @@
+resource_group_name = "test-rg"
+location            = "eastus"
+kubernetes_version  = "1.27.3"
+node_count          = 1

--- a/envs/test/variables.tf
+++ b/envs/test/variables.tf
@@ -1,0 +1,4 @@
+variable "resource_group_name" { type = string }
+variable "location" { type = string }
+variable "kubernetes_version" { type = string }
+variable "node_count" { type = number }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+module "aks" {
+  for_each = var.environments
+
+  source              = "./modules/aks"
+  environment         = each.key
+  resource_group_name = each.value.resource_group_name
+  location            = each.value.location
+  kubernetes_version  = each.value.kubernetes_version
+  node_count          = each.value.node_count
+}

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -1,0 +1,28 @@
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = "${var.environment}-aks"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "${var.environment}-aks"
+
+  kubernetes_version = var.kubernetes_version
+
+  default_node_pool {
+    name       = "default"
+    node_count = var.node_count
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+output "kube_config" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive = true
+}

--- a/modules/aks/variables.tf
+++ b/modules/aks/variables.tf
@@ -1,0 +1,24 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure location"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the default node pool"
+  type        = number
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,5 @@
+output "kube_configs" {
+  value       = { for env, mod in module.aks : env => mod.kube_config }
+  description = "Kubeconfigs for each environment"
+  sensitive   = true
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,20 @@
+environments = {
+  dev = {
+    resource_group_name = "dev-rg"
+    location            = "eastus"
+    kubernetes_version  = "1.27.3"
+    node_count          = 1
+  }
+  test = {
+    resource_group_name = "test-rg"
+    location            = "eastus"
+    kubernetes_version  = "1.27.3"
+    node_count          = 1
+  }
+  prod = {
+    resource_group_name = "prod-rg"
+    location            = "eastus"
+    kubernetes_version  = "1.27.3"
+    node_count          = 3
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "environments" {
+  type = map(object({
+    resource_group_name = string
+    location            = string
+    kubernetes_version  = string
+    node_count          = number
+  }))
+  description = "Environment specific AKS settings"
+}


### PR DESCRIPTION
## Summary
- document environment folders in README
- add `envs` directory with Terraform configs for dev, test and prod

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6862ce09387c83308bdcf59d96b610fd